### PR TITLE
refactor(medicine): remove unused fields from Medicine interface and clean up MedicinesPage component

### DIFF
--- a/src/data/interfaces/medicine.interface.ts
+++ b/src/data/interfaces/medicine.interface.ts
@@ -15,12 +15,6 @@ export interface Medicine {
   supplier: Supplier;
   details: Details;
   usageguide: UsageGuide;
-  // Additional fields that might come from Laravel API
-  price?: number; // Direct price field from Laravel
-  stock?: number; // Stock quantity from Laravel
-  category_id?: string; // Category ID from Laravel
-  readonly created_at?: string; // Laravel snake_case
-  readonly updated_at?: string; // Laravel snake_case
   readonly createdAt?: string; 
   readonly updatedAt?: string;
 }

--- a/src/page/store/medicines/page.tsx
+++ b/src/page/store/medicines/page.tsx
@@ -141,7 +141,6 @@ export default function MedicinesPage() {
         setSelectedCategories(matchedCategories);
       }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [categoryFromUrl, categories]);
 
   // Update display price with delay to prevent flickering during sliding


### PR DESCRIPTION
- Removed optional fields related to Laravel API from Medicine interface for clarity.
- Cleaned up MedicinesPage component by removing unnecessary ESLint disable comment.